### PR TITLE
Backend serves React client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Backend client dist
+backend/priv/static/*

--- a/backend/gleam.toml
+++ b/backend/gleam.toml
@@ -19,6 +19,7 @@ sqlight = ">= 0.9.1 and < 1.0.0"
 mist = ">= 2.0.0 and < 3.0.0"
 gleam_erlang = ">= 0.26.0 and < 1.0.0"
 gleam_http = ">= 3.7.0 and < 4.0.0"
+simplifile = ">= 2.2.0 and < 3.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/backend/manifest.toml
+++ b/backend/manifest.toml
@@ -23,7 +23,7 @@ packages = [
   { name = "mist", version = "2.0.0", build_tools = ["gleam"], requirements = ["birl", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "981F12FC8BA0656B40099EC876D6F2BEE7B95593610F342E9AB0DC4E663A932F" },
   { name = "platform", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "platform", source = "hex", outer_checksum = "8339420A95AD89AAC0F82F4C3DB8DD401041742D6C3F46132A8739F6AEB75391" },
   { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
-  { name = "simplifile", version = "2.1.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "BDD04F5D31D6D34E2EDFAEF0B68A6297AEC939888C3BFCE61133DE13857F6DA2" },
+  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
   { name = "sqlight", version = "0.9.1", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "A495F2892627B2268CCBCC5107EDC1E1AD9547D5F4F21A5DB04CEA72B8931B00" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
   { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
@@ -36,5 +36,6 @@ gleam_http = { version = ">= 3.7.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mist = { version = ">= 2.0.0 and < 3.0.0" }
+simplifile = { version = ">= 2.2.0 and < 3.0.0" }
 sqlight = { version = ">= 0.9.1 and < 1.0.0" }
 wisp = { version = ">= 1.1.0 and < 2.0.0" }

--- a/backend/src/app/router.gleam
+++ b/backend/src/app/router.gleam
@@ -1,11 +1,18 @@
-import app/web
+import app/web.{type Context}
 import gleam/string_builder
+import simplifile
 import wisp.{type Request, type Response}
 
-pub fn handle_request(req: Request) -> Response {
-  use _req <- web.middleware(req)
+pub fn handle_request(req: Request, ctx: Context) -> Response {
+  use _req <- web.middleware(req, ctx)
 
-  let body = string_builder.from_string("<h1>Hello, Joe!</h1>")
+  let path = static_directory()
+  let assert Ok(body) = simplifile.read(path <> "/index.html")
 
-  wisp.html_response(body, 200)
+  wisp.html_response(string_builder.from_string(body), 200)
+}
+
+pub fn static_directory() -> String {
+  let assert Ok(priv_directory) = wisp.priv_directory("backend")
+  priv_directory <> "/static"
 }

--- a/backend/src/app/web.gleam
+++ b/backend/src/app/web.gleam
@@ -1,14 +1,17 @@
-import gleam/http
-import gleam/int
-import gleam/string
-import mist
 import wisp
+
+pub type Context {
+  Context(static_directory: String)
+}
 
 pub fn middleware(
   req: wisp.Request,
+  ctx: Context,
   handle_request: fn(wisp.Request) -> wisp.Response,
 ) -> wisp.Response {
   use <- wisp.log_request(req)
   use <- wisp.rescue_crashes
+  use <- wisp.serve_static(req, under: "", from: ctx.static_directory)
+
   handle_request(req)
 }

--- a/backend/src/backend.gleam
+++ b/backend/src/backend.gleam
@@ -1,4 +1,5 @@
 import app/router
+import app/web.{Context}
 import gleam/erlang/os
 import gleam/erlang/process
 import gleam/http/request.{type Request}
@@ -26,9 +27,11 @@ pub fn main() {
 }
 
 fn start_dev() {
-  let secrect_key_base = wisp.random_string(64)
+  let secret_key_base = wisp.random_string(64)
+  let ctx = Context(router.static_directory())
+
   let assert Ok(result) =
-    handler(router.handle_request, secrect_key_base)
+    handler(router.handle_request(_, ctx), secret_key_base)
     |> mist.new
     |> mist.port(8080)
     |> mist.start_http
@@ -37,9 +40,11 @@ fn start_dev() {
 }
 
 fn start_prod() {
-  let secrect_key_base = wisp.random_string(64)
+  let secret_key_base = wisp.random_string(64)
+  let ctx = Context(router.static_directory())
+
   let assert Ok(result) =
-    handler(router.handle_request, secrect_key_base)
+    handler(router.handle_request(_, ctx), secret_key_base)
     |> mist.new
     |> mist.port(443)
     |> mist.start_https(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && cp -r ./dist/* ../backend/priv/static",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
- Gleam backend serves static React client (uses simplifile package to read index.html, rest is fetched)
- React project build copies dist files to backend's "static" folder. I would've liked to read directly from the frontend project's "dist" folder but Gleam was being funny about file paths so this was not a bad alternative. I added the dist files to the .gitignore so we don't flood the repo with conflicts.