### PR TITLE
Reduce CI usage

### DIFF
--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -6,32 +6,46 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27.1.2"
           gleam-version: "1.5.1"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
-      
-      - run: gleam deps download
-        working-directory: ./backend
-      - run: gleam check
-        working-directory: ./backend
-        env: 
-          ESQLITE_CFLAGS: "-O0"
-      # - run: gleam test
-      #   working-directory: ./backend
-      - run: gleam format --check src test
-        working-directory: ./backend
-      - run: gleam test
-        working-directory: ./backend
+
+
       - name: Cache Gleam Packages
         uses: actions/cache@v3
         with:
             path: |
+              ./backend/build/dev/erlang
               ./backend/build/packages
+            key: ${{ runner.os }}-gleam-${{ hashFiles('./backend/manifest.toml') }}
+            restore-keys: |
+              ${{ runner.os }}-gleam-
+
+
+      - run: gleam deps download
+        working-directory: ./backend
+
+      - run: gleam format --check src test
+        working-directory: ./backend
+
+      - run: gleam check
+        working-directory: ./backend
+        env: 
+          ESQLITE_CFLAGS: "-O0"
+
+      - run: gleam test
+        working-directory: ./backend
+      

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Cancel stale CI runs (thanks https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions)
- Properly cache gleam deps so we don't need to rebuild sqlite every time