### PR TITLE
Join Project API

### DIFF
--- a/backend/priv/schema.sql
+++ b/backend/priv/schema.sql
@@ -27,5 +27,7 @@ create index if not exists idx_projects_projectid on projects(projectid);
 create table if not exists user_projects (
     userid text not null,
     projectid text not null,
+    foreign key (userid) references users(userid)
+    foreign key (projectid) references projects(projectid)
     primary key (userid, projectid)
 ) strict;

--- a/backend/src/backend/db.gleam
+++ b/backend/src/backend/db.gleam
@@ -58,7 +58,19 @@ pub fn create_project(
   use returned <- result.then(res)
   let assert [] = returned
 
-  let params = [sqlight.text(project.projectid), sqlight.text(userid)]
+  let returned = join_project(db, project.projectid, userid)
+  let assert Ok(Nil) = returned
+
+  Ok(Nil)
+}
+
+pub fn join_project(
+  db: web.Connection,
+  projectid: String,
+  userid: String,
+) -> Result(Nil, Error) {
+  let decoder = fn(dyn: Dynamic) { Ok(Nil) }
+  let params = [sqlight.text(projectid), sqlight.text(userid)]
   let res = sql.add_user_to_project(db.inner, params, decoder)
 
   wisp.log_info("DB add_user_to_project " <> string.inspect(res))

--- a/backend/src/backend/project.gleam
+++ b/backend/src/backend/project.gleam
@@ -19,3 +19,19 @@ pub fn create_project(
   |> result.map(mapper)
   |> result.unwrap(or: wisp.response(401))
 }
+
+pub fn join_project(
+  projectid: String,
+  jwt: gwt.Jwt(gwt.Verified),
+  ctx: web.Context,
+) -> wisp.Response {
+  let mapper = fn(userid: String) {
+    db.join_project(ctx.db, projectid, userid)
+    |> result.map(fn(_) { wisp.response(201) })
+    |> result.unwrap(or: wisp.bad_request())
+  }
+
+  gwt.get_subject(jwt)
+  |> result.map(mapper)
+  |> result.unwrap(or: wisp.response(401))
+}

--- a/backend/src/backend/router.gleam
+++ b/backend/src/backend/router.gleam
@@ -101,7 +101,7 @@ pub fn auth(req: wisp.Request, ctx: Context) -> wisp.Response {
   }
 }
 
-// Priveledged API
+// Privileged API
 pub fn project(req: wisp.Request, ctx: Context) -> wisp.Response {
   let assert ["api", "v1", "project", ..route] = wisp.path_segments(req)
 
@@ -126,11 +126,10 @@ pub fn project(req: wisp.Request, ctx: Context) -> wisp.Response {
 
           project.create_project(web.Project(projectid, description), jwt, ctx)
         }
-        // Put -> {
-        //   // Add a user to a project
-        //   use <- wisp.require_method(req, http.Put)
-        //   wisp.response(501)
-        // }
+        Put -> {
+          // Add calling user to a project
+          project.join_project(projectid, jwt, ctx)
+        }
         // Delete -> {
         //   // Delete a project (and associated user connections)
         //   use <- wisp.require_method(req, http.Delete)
@@ -144,7 +143,7 @@ pub fn project(req: wisp.Request, ctx: Context) -> wisp.Response {
   }
 }
 
-// Priveledged API
+// Privileged API
 pub fn hardware(req: wisp.Request, ctx: Context) -> wisp.Response {
   wisp.response(501)
 }

--- a/backend/test/backend_test.gleam
+++ b/backend/test/backend_test.gleam
@@ -201,6 +201,89 @@ pub fn project_api_cant_create_identical_project_test() {
   response.status
   |> should.equal(400)
 }
+
+pub fn project_api_join_project_test() {
+  use ctx <- with_context
+  use <- with_logger
+
+  // need to create and log in user before we can test the project creation
+  let request =
+    testing.post("/api/v1/auth/signup?userid=foo&password=bar", [], "")
+  let response = router.handle_request(request, ctx)
+
+  response.status
+  |> should.equal(201)
+
+  let request =
+    testing.post("/api/v1/auth/login?userid=foo&password=bar", [], "")
+  let response = router.handle_request(request, ctx)
+
+  response.status
+  |> should.equal(201)
+
+  response.headers
+  |> should.equal([#("content-type", "application/json; charset=utf-8")])
+
+  let assert wisp.Text(jwt) = response.body
+  let token = string_builder.to_string(jwt)
+
+  // Create a test project which we'll be automatically added to.
+  let request =
+    testing.post(
+      "/api/v1/project/foo?description=bar",
+      [#("authorization", token)],
+      "",
+    )
+  let response = router.handle_request(request, ctx)
+
+  response.status
+  |> should.equal(201)
+
+  // Try joining the same project, which should fail
+  let request =
+    testing.put("/api/v1/project/foo", [#("authorization", token)], "")
+  let response = router.handle_request(request, ctx)
+
+  response.status
+  |> should.equal(400)
+
+  // Try joining a non existent project, which should fail
+  let request =
+    testing.put("/api/v1/project/bar", [#("authorization", token)], "")
+  let response = router.handle_request(request, ctx)
+
+  response.status
+  |> should.equal(400)
+
+  // New user to join an existing project
+  let request =
+    testing.post("/api/v1/auth/signup?userid=bar&password=foo", [], "")
+  let response = router.handle_request(request, ctx)
+
+  response.status
+  |> should.equal(201)
+
+  let request =
+    testing.post("/api/v1/auth/login?userid=bar&password=foo", [], "")
+  let response = router.handle_request(request, ctx)
+
+  response.status
+  |> should.equal(201)
+
+  response.headers
+  |> should.equal([#("content-type", "application/json; charset=utf-8")])
+
+  let assert wisp.Text(jwt) = response.body
+  let token = string_builder.to_string(jwt)
+
+  // Try joining an existing project as a new user.
+  let request =
+    testing.put("/api/v1/project/foo", [#("authorization", token)], "")
+  let response = router.handle_request(request, ctx)
+
+  response.status
+  |> should.equal(201)
+}
 // pub fn project_api_test() {
 //   use ctx <- with_context
 


### PR DESCRIPTION
Query, route, and tests for joining an existing project. Updated bridge table with foreign key markers to ensure projectid passed to query matches an existing project.